### PR TITLE
Improve semantics of shape spec

### DIFF
--- a/spec/shape_spec.rb
+++ b/spec/shape_spec.rb
@@ -1,39 +1,41 @@
 require_relative '../lib/shape.rb'
 
-context "Shape" do
+describe 'Shape' do
+  subject(:shape) { Shape.new(4, 10) }
 
-  before(:context) do
-    @shape = Shape.new(4, 10)
+  it 'is a shape' do
+    expect(subject).to be_a(Shape)
   end
 
-  context "initialized in before(:context)" do
+  it 'has required attributes' do
+    expect(subject.instance_variables).to include(:@num_sides)
+    expect(subject.instance_variables).to include(:@side_length)
+  end
 
-    describe ".num_sides" do
-      it "is readable" do
-        expect(@shape.num_sides).to eq(4)
-      end
-      it "is not editable" do
-        expect{@shape.num_sides = 8}.to raise_error(NoMethodError)
-      end
+  it 'has getters for @num_sides, @side_length, and @color' do
+    expect { subject.num_sides }.not_to raise_error
+    expect { subject.side_length }.not_to raise_error
+    expect { subject.color }.not_to raise_error
+  end
+
+  it 'has no setter for @num_sides' do
+    expect { subject.num_sides = 4 }.to raise_error(NoMethodError)
+  end
+
+  it 'has setters for @side_length and @color' do
+    expect { subject.side_length = 4 }.not_to raise_error
+    expect { subject.color = 'red' }.not_to raise_error
+  end
+
+  describe '@color' do
+    it 'is not set on initialization' do
+      expect(subject.instance_variables).not_to include(:@color)
     end
 
-    describe ".side_length" do
-      it "is readable" do
-        expect(@shape.side_length).to eq(10)
-      end
-      it "is writeable" do
-        @shape.side_length = 25
-        expect(@shape.side_length).to eq(25)
-      end
+    it 'is set after assignment' do
+      subject.color = 'red'
+      expect(subject.instance_variables).to include(:@color)
     end
-
-    describe ".color" do
-      it "is writeable and readable" do
-        @shape.color = "red"
-        expect(@shape.color).to eq("red")
-      end
-    end
-
   end
 
   describe ".calculate_area" do
@@ -43,5 +45,4 @@ context "Shape" do
       expect(Shape.new(9,13).calculate_area.round(2)).to eq(1044.73)
     end
   end
-
 end


### PR DESCRIPTION
-   Prefer `describe` to `context`
-   Use subject instead of instance variables
-   Add sanity tests
-   Only test minimal behavior
-   Remove tests that test the Ruby language

Closes #11 
